### PR TITLE
YESROD FORGOT A PERIOD

### DIFF
--- a/ansible/roles/dns/templates/magevent.net.zone.j2
+++ b/ansible/roles/dns/templates/magevent.net.zone.j2
@@ -1,4 +1,4 @@
-$ORIGIN {{ zone_prefix }}magevent.net
+$ORIGIN {{ zone_prefix }}magevent.net.
 $TTL 3600
 ; {{ zone_prefix }}magevent.net
 @ IN SOA dns1.{{ zone_prefix }}magevent.net. admin.{{ zone_prefix }}magevent.net. (


### PR DESCRIPTION
Turns out the period at the end of the DNS name in the $ORIGIN statement in a
zone file is really important.

🔔SHAME🔔SHAME🔔SHAME🔔