### PR TITLE
fix: dumb copypasta error

### DIFF
--- a/ansible/roles/dns/templates/named.conf.local.j2
+++ b/ansible/roles/dns/templates/named.conf.local.j2
@@ -25,7 +25,6 @@ zone "{{ zone_prefix }}magevent.net" IN {
 zone "win.magevent.net" {
         type stub;
         masters {10.101.22.210; 10.101.22.220;};
-        allow-notify {10.101.22.210; 10.101.22.220;};
         file "/var/lib/bind/win.magevent.net.zone";
         forwarders { };
 };


### PR DESCRIPTION
Missed that win.magevent.net was a stub zone, and thus doesn't support the allow-notify parameter.