### PR TITLE
Fix LibreNMS resources, GitHub Pages cruft

### DIFF
--- a/ansible/roles/ubuntu/templates/etc_hosts.j2
+++ b/ansible/roles/ubuntu/templates/etc_hosts.j2
@@ -1,5 +1,5 @@
 127.0.0.1       localhost
-127.0.1.1       {{ ansible_hostname }}.{{ ansible_fqdn }} {{ ansible_hostname }}
+127.0.1.1       {{ ansible_hostname }}.{{ ansible_domain }} {{ ansible_hostname }}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1     ip6-localhost ip6-loopback
@@ -10,6 +10,6 @@ ff02::2 ip6-allrouters
 
 {% for item in magevent_net_hosts %}
 {% if item.type == "A" or item.type == "AAAA" %}
-{{ item.ip }}       {{ item.name }}.{{ ansible_fqdn }} {{ item.name }}
+{{ item.ip }}       {{ item.name }}.{{ ansible_domain }} {{ item.name }}
 {% endif %}
 {% endfor %}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-hacker

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-hacker
+theme: jekyll-theme-minimal

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
+---
 theme: jekyll-theme-minimal

--- a/terraform/lxc-librenms.tf
+++ b/terraform/lxc-librenms.tf
@@ -1,6 +1,8 @@
 module "librenms" {
   source       = "./modules/lxc"
   cluster_name = "pve1"
+  memory       = "1024"
+  cores        = "2"
   gateway      = cidrhost(var.subnet, 1)
   hostname     = "librenms-21.${local.domain}"
   nets = [

--- a/terraform/modules/lxc/main.tf
+++ b/terraform/modules/lxc/main.tf
@@ -14,7 +14,7 @@ resource "proxmox_lxc" "lxc-container" {
   unprivileged    = true
   hostname        = var.hostname
   memory          = var.memory
-  cores           = "1"
+  cores           = var.cores
   swap            = "512"
   start           = true
   hastate         = "started"
@@ -75,6 +75,12 @@ variable "size" {
   description = "Size of fs in gigabytes"
   type        = string
   default     = "8G"
+}
+
+variable "cores" {
+  description = "CPU cores"
+  type        = string
+  default     = "1"
 }
 
 variable "memory" {


### PR DESCRIPTION
The LibreNMS container had been changed to 2 cores and 1GB RAM, so we need to account for that change in Terraform.  This also adds the ability to override cores for a specific container.

Also, while fiddling with GitHub pages it decided to make a bunch of commits to prod without telling me, so, yay.  This should fix that as well.