### PR TITLE
fix: add apt-mirror.magevent.net

### DIFF
--- a/ansible/inventory/group_vars/all/dns.yaml
+++ b/ansible/inventory/group_vars/all/dns.yaml
@@ -81,3 +81,4 @@ magevent_net_hosts:
   - { name: "coldbrew", ip: "hydrophobic-pheasant-7qpulrttf80t5n3leh0etcff.herokudns.com.", type: "CNAME" }
   - { name: "schedule", ip: "schedule.magevent.net.s3-website-us-east-1.amazonaws.com.", type: "CNAME" }
   - { name: "food", ip: "157.245.3.204", type: "A" }
+  - { name: "apt-mirror", ip: "d1oyui1gsktpjk.cloudfront.net.", type: "CNAME"}


### PR DESCRIPTION
This is needed for the laptops.  Apt has a mechanism to select mirrors based on a text file downloaded from a URL like `mirror://apt-mirror.magevent.net/mirrors.txt`.  This is set up on AWS externally, but internally we need to CNAME to it.

Need this into `prod` so the prod servers have that CNAME.