### PR TITLE
fix: disable NetworkManager MAC randomization

### DIFF
--- a/ansible/roles/ubuntu/files/disable_randmac.conf
+++ b/ansible/roles/ubuntu/files/disable_randmac.conf
@@ -1,0 +1,2 @@
+[device]
+wifi.scan-rand-mac-address=no

--- a/ansible/roles/ubuntu/tasks/ubuntu_laptops.yaml
+++ b/ansible/roles/ubuntu/tasks/ubuntu_laptops.yaml
@@ -18,6 +18,14 @@
     mode: 0600
   with_items: "{{ wifi_creds }}"
 
+- name: Disable NetworkManager MAC randomization
+  ansible.builtin.copy:
+    src: "disable_randmac.conf"
+    dest: "/etc/NetworkManager/conf.d/disable_randmac.conf"
+    owner: root
+    group: root
+    mode: 0644
+
 - name: Create dconf directory for background config
   ansible.builtin.file:
     path: "/etc/dconf/db/local.d/"


### PR DESCRIPTION
Laptops need this disabled to avoid breaking our wireless network or
something.

Sorry @rscullin I almost forgot this.