### PR TITLE
feat: register laptops in Snipe-IP after install

### DIFF
--- a/ansible/roles/ubuntu/files/snipe-register.sh
+++ b/ansible/roles/ubuntu/files/snipe-register.sh
@@ -7,7 +7,7 @@
 if [ ! -f /opt/snipeit-register ]
 then
     sudo apt-get install hwinfo curl jq dmidecode -y
-    
+
     SNIPE_SERVICE_TAG=$(sudo dmidecode -s system-serial-number)
     SNIPE_MFG=$(dmidecode -s system-manufacturer)
     SNIPE_MODEL=$(dmidecode -s system-product-name)
@@ -15,12 +15,12 @@ then
     SNIPE_ETH0=$(cat /sys/class/net/eth0/address)
     SNIPE_WLAN0=$(cat /sys/class/net/wlan0/address)
     SNIPE_MEMORY=$(getconf -a | grep PAGES | awk 'BEGIN {total = 1} {if (NR == 1 || NR == 3) total *=$NF} END {print total / 1024" kB"}')
-    
+
     echo "Registering device with Snipe-IT"
     curl -d "{\"service_tag\":\"$SNIPE_SERVICE_TAG\", \"manufacturer\":\"$SNIPE_MFG\", \"model_number\":\"$SNIPE_MODEL\", \"cpu\":\"$SNIPE_CPU\", \"memory\":\"$SNIPE_MEMORY\", \"wlan0\":\"$SNIPE_WLAN0\", \"eth0\":\"$SNIPE_ETH0\"}" \
       -H "Content-Type: application/json" \
       "https://5860c07ffa274f384856076929733fb6.m.pipedream.net"
-    
+
     touch /opt/snipeit-register
 else
     echo "Device has already been registered with Snipe-IT. Exiting."

--- a/ansible/roles/ubuntu/tasks/ubuntu_laptops.yaml
+++ b/ansible/roles/ubuntu/tasks/ubuntu_laptops.yaml
@@ -78,3 +78,16 @@
 
 - name: Install login screen background
   command: "/usr/local/bin/change-gdm-background /usr/share/backgrounds/MAG2022_lockscreen.png"
+
+- name: Install Snipe-IT registry script
+  ansible.builtin.copy:
+    src: "snipe-register.sh"
+    dest: "/usr/local/bin/snipe-register.sh"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Register in Snipe-IP
+  command: "/usr/local/bin/snipe-register.sh"
+  args:
+    creates: "/opt/snipeit-register"


### PR DESCRIPTION
Thanks to a script from @jasonspriggs we can register the laptops in Snipe-IP after install.

This gets us at least some inventory tracking and host information stuff.