### PR TITLE
fix: decrease log spam

### DIFF
--- a/ansible/roles/asterisk/files/logger.conf
+++ b/ansible/roles/asterisk/files/logger.conf
@@ -1,0 +1,166 @@
+;
+; Logging Configuration
+;
+; In this file, you configure logging to files or to
+; the syslog system.
+;
+; "logger reload" at the CLI will reload configuration
+; of the logging system.
+
+[general]
+;
+; Customize the display of debug message time stamps
+; this example is the ISO 8601 date format (yyyy-mm-dd HH:MM:SS)
+;
+; see strftime(3) Linux manual for format specifiers.  Note that there is also
+; a fractional second parameter which may be used in this field.  Use %1q
+; for tenths, %2q for hundredths, etc.
+;
+;dateformat=%F %T       ; ISO 8601 date format
+;dateformat=%F %T.%3q   ; with milliseconds
+;
+;
+; This makes Asterisk write callids to log messages
+; (defaults to yes)
+;use_callids = no
+;
+; This appends the hostname to the name of the log files.
+;appendhostname = yes
+;
+; This determines whether or not we log queue events to a file
+; (defaults to yes).
+;queue_log = no
+;
+; Determines whether the queue_log always goes to a file, even
+; when a realtime backend is present (defaults to no).
+;queue_log_to_file = yes
+;
+; Set the queue_log filename
+; (defaults to queue_log)
+;queue_log_name = queue_log
+;
+; When using realtime for the queue log, use GMT for the timestamp
+; instead of localtime.  The default of this option is 'no'.
+;queue_log_realtime_use_gmt = yes
+;
+; Log rotation strategy:
+; none:  Do not perform any logrotation at all.  You should make
+;        very sure to set up some external logrotate mechanism
+;        as the asterisk logs can get very large, very quickly.
+; sequential:  Rename archived logs in order, such that the newest
+;              has the highest sequence number [default].  When
+;              exec_after_rotate is set, ${filename} will specify
+;              the new archived logfile.
+; rotate:  Rotate all the old files, such that the oldest has the
+;          highest sequence number [this is the expected behavior
+;          for Unix administrators].  When exec_after_rotate is
+;          set, ${filename} will specify the original root filename.
+; timestamp:  Rename the logfiles using a timestamp instead of a
+;             sequence number when "logger rotate" is executed.
+;             When exec_after_rotate is set, ${filename} will
+;             specify the new archived logfile.
+rotatestrategy = rotate
+;
+; Run a system command after rotating the files.  This is mainly
+; useful for rotatestrategy=rotate. The example allows the last
+; two archive files to remain uncompressed, but after that point,
+; they are compressed on disk.
+;
+exec_after_rotate=gzip -9 ${filename}.2
+;
+;
+; For each file, specify what to log.
+;
+; For console logging, you set options at start of
+; Asterisk with -v for verbose and -d for debug
+; See 'asterisk -h' for more information.
+;
+; Directory for log files is configures in asterisk.conf
+; option astlogdir
+;
+; All log messages go to a queue serviced by a single thread
+; which does all the IO.  This setting controls how big that
+; queue can get (and therefore how much memory is allocated)
+; before new messages are discarded.
+; The default is 1000
+;logger_queue_limit = 250
+;
+;
+[logfiles]
+;
+; Format is:
+;
+; logger_name => [formatter]levels
+;
+; The name of the logger dictates not only the name of the logging
+; channel, but also its type. Valid types are:
+;   - 'console'  - The root console of Asterisk
+;   - 'syslog'   - Linux syslog, with facilities specified afterwards with
+;                  a period delimiter, e.g., 'syslog.local0'
+;   - 'filename' - The name of the log file to create. This is the default
+;                  for log channels.
+;
+; Filenames can either be relative to the standard Asterisk log directory
+; (see 'astlogdir' in asterisk.conf), or absolute paths that begin with
+; '/'.
+;
+; An optional formatter can be specified prior to the log levels sent
+; to the log channel. The formatter is defined immediately preceeding the
+; levels, and is enclosed in square brackets. Valid formatters are:
+;   - [default] - The default formatter, this outputs log messages using a
+;                 human readable format.
+;   - [json]    - Log the output in JSON. Note that JSON formatted log entries,
+;                 if specified for a logger type of 'console', will be formatted
+;                 per the 'default' formatter for log messages of type VERBOSE.
+;                 This is due to the remote consoles intepreting verbosity
+;                 outside of the logging subsystem.
+;
+; Log levels include the following, and are specified in a comma delineated
+; list:
+;    debug
+;    notice
+;    warning
+;    error
+;    verbose(<level>)
+;    dtmf
+;    fax
+;    security
+;
+; Verbose takes an optional argument, in the form of an integer level.
+; Verbose messages with higher levels will not be logged to the file.  If
+; the verbose level is not specified, it will log verbose messages following
+; the current level of the root console.
+;
+; Special level name "*" means all levels, even dynamic levels registered
+; by modules after the logger has been initialized (this means that loading
+; and unloading modules that create/remove dynamic logger levels will result
+; in these levels being included on filenames that have a level name of "*",
+; without any need to perform a 'logger reload' or similar operation).
+; Note that there is no value in specifying both "*" and specific level names
+; for a filename; the "*" level means all levels.  The only exception is if
+; you need to specify a specific verbose level. e.g, "verbose(3),*".
+;
+; We highly recommend that you DO NOT turn on debug mode if you are simply
+; running a production system.  Debug mode turns on a LOT of extra messages,
+; most of which you are unlikely to understand without an understanding of
+; the underlying code.  Do NOT report debug messages as code issues, unless
+; you have a specific issue that you are attempting to debug.  They are
+; messages for just that -- debugging -- and do not rise to the level of
+; something that merit your attention as an Asterisk administrator.  Debug
+; messages are also very verbose and can and do fill up logfiles quickly;
+; this is another reason not to have debug mode on a production system unless
+; you are in the process of debugging a specific issue.
+;
+;debug => debug
+;security => security
+;console => notice,warning,error
+;console => notice,warning,error,debug
+messages => notice,warning,error
+;full => notice,warning,error,debug,verbose,dtmf,fax
+;
+;full-json => [json]debug,verbose,notice,warning,error,dtmf,fax
+;
+;syslog keyword : This special keyword logs to syslog facility
+;
+;syslog.local0 => notice,warning,error
+;

--- a/ansible/roles/asterisk/tasks/asterisk.yaml
+++ b/ansible/roles/asterisk/tasks/asterisk.yaml
@@ -22,6 +22,7 @@
   - "confbridge.conf"
   - "queues.conf"
   - "iax.conf"
+  - "logger.conf"
 
 - name: Copy sound files
   ansible.builtin.copy:

--- a/ansible/roles/voip_provision/defaults/main.yaml
+++ b/ansible/roles/voip_provision/defaults/main.yaml
@@ -25,7 +25,7 @@ provisioner_config:
   update_interval: 60
   logging:
     file_path: /var/log/voip-provision.log
-    file_level: debug
+    file_level: info
     console_level: info
     syslog_path: /dev/log
-    syslog_level: debug
+    syslog_level: info


### PR DESCRIPTION
- Asterisk: Compress rotated logs and don't log to console/syslog
- Provisioner: Log at info level, not debug