### PR TITLE
Proxy fixes 4: Proxy harder

### DIFF
--- a/ansible/group_vars/all/dns.yaml
+++ b/ansible/group_vars/all/dns.yaml
@@ -172,6 +172,8 @@ magevent_net_hosts:
   - { name: "pve2", ip: "10.101.21.42", type: "A" }
   - { name: "pve-vampire", ip: "10.101.21.44", type: "A" }
   - { name: "synology", ip: "10.101.21.156", type: "A" }
+  - { name: "synrepo", ip: "10.101.21.156", type: "A" }
+
 
   # IPMI
   - { name: "dell-omsa", ip: "192.168.100.110", type: "A" }

--- a/ansible/roles/nginx-proxy/files/repo_proxy.conf
+++ b/ansible/roles/nginx-proxy/files/repo_proxy.conf
@@ -1,17 +1,15 @@
-http {
-  proxy_cache_path  /var/www/cache levels=1:2 keys_zone=my-cache:8m max_size=1000m inactive=600m;
-    proxy_temp_path /var/www/cache/tmp;
-    server {
-    listen 80;
-    location / {
-      proxy_pass http://synology.magevent.net;
-      proxy_set_header Host synrepo.magevent.net;
-      proxy_set_header X-Real-IP $remote_addr;
-    }
-      proxy_buffers 16 4k;
-      proxy_buffer_size 2k;
-      proxy_cache my-cache;
-      proxy_cache_valid  200 302  60m;
-      proxy_cache_valid  404      1m;
+proxy_cache_path  /var/www/cache levels=1:2 keys_zone=my-cache:8m max_size=1000m inactive=600m;
+  proxy_temp_path /var/www/cache/tmp;
+  server {
+  listen 80;
+  location / {
+    proxy_pass http://synology.magevent.net;
+    proxy_set_header Host synrepo.magevent.net;
+    proxy_set_header X-Real-IP $remote_addr;
   }
+    proxy_buffers 16 4k;
+    proxy_buffer_size 2k;
+    proxy_cache my-cache;
+    proxy_cache_valid  200 302  60m;
+    proxy_cache_valid  404      1m;
 }

--- a/ansible/roles/nginx-proxy/files/repo_proxy.conf
+++ b/ansible/roles/nginx-proxy/files/repo_proxy.conf
@@ -1,7 +1,7 @@
 proxy_cache_path  /var/www/cache levels=1:2 keys_zone=my-cache:8m max_size=1000m inactive=600m;
-  proxy_temp_path /var/www/cache/tmp;
-  server {
-  listen 80;
+proxy_temp_path /var/www/cache/tmp;
+server {
+  listen 80 default_server;
   location / {
     proxy_pass http://synology.magevent.net;
     proxy_set_header Host synrepo.magevent.net;

--- a/ansible/roles/nginx-proxy/tasks/server.yaml
+++ b/ansible/roles/nginx-proxy/tasks/server.yaml
@@ -25,3 +25,4 @@
     dest: /etc/nginx/sites-enabled/repo_proxy.conf 
     src: /etc/nginx/sites-available/repo_proxy.conf
     state: link
+    force: true

--- a/ansible/roles/nginx-proxy/tasks/server.yaml
+++ b/ansible/roles/nginx-proxy/tasks/server.yaml
@@ -13,7 +13,7 @@
 - name: Copy repo_proxy.conf
   ansible.builtin.copy:
     src: files/repo_proxy.conf
-    dest: /etc/nginx/sites-enabled/repo_proxy.conf
+    dest: /etc/nginx/sites-available/repo_proxy.conf
     mode: "0644"
     owner: root
     group: root
@@ -22,6 +22,6 @@
 
 - name: Link NGINX Reverse Proxy
   ansible.builtin.file:
-    dest: /etc/nginx/sites-available/repo_proxy.conf 
-    src: /etc/nginx/sites-enabled/repo_proxy.conf
+    dest: /etc/nginx/sites-enabled/repo_proxy.conf 
+    src: /etc/nginx/sites-available/repo_proxy.conf
     state: link

--- a/ansible/roles/nginx-proxy/tasks/server.yaml
+++ b/ansible/roles/nginx-proxy/tasks/server.yaml
@@ -22,7 +22,17 @@
 
 - name: Link NGINX Reverse Proxy
   ansible.builtin.file:
-    dest: /etc/nginx/sites-enabled/repo_proxy.conf 
+    dest: /etc/nginx/sites-enabled/repo_proxy.conf
     src: /etc/nginx/sites-available/repo_proxy.conf
     state: link
     force: true
+  notify:
+    - Restart nginx
+
+- name: Disable NGINX default config
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+    force: true
+  notify:
+    - Restart nginx


### PR DESCRIPTION
- NGINX config formatting
- NGINX config in wrong place, fixed
- Added synrepo DNS entry
- Config symlink overrides existing files
- Remove default config
- Make proxy config default