### PR TITLE
Fix Zabbix agent

### DIFF
--- a/ansible/roles/zabbix_agent/tasks/apt.yaml
+++ b/ansible/roles/zabbix_agent/tasks/apt.yaml
@@ -12,7 +12,7 @@
 - name: Install Zabbix agent
   ansible.builtin.apt:
     name: "{{ defaults.packages.zabbix_agent }}"
-    state: present
+    state: latest
     install_recommends: false
     update_cache: true
     cache_valid_time: 3600

--- a/ansible/roles/zabbix_agent/tasks/apt.yaml
+++ b/ansible/roles/zabbix_agent/tasks/apt.yaml
@@ -3,8 +3,18 @@
   ansible.builtin.apt:
     deb: "{{ defaults.packages.zabbix_repo }}"
     state: present
+    install_recommends: false
+    update_cache: true
+    cache_valid_time: 3600
+    autoclean: true
+    autoremove: true
 
 - name: Install Zabbix agent
   ansible.builtin.apt:
     name: "{{ defaults.packages.zabbix_agent }}"
     state: present
+    install_recommends: false
+    update_cache: true
+    cache_valid_time: 3600
+    autoclean: true
+    autoremove: true


### PR DESCRIPTION
When this got pushed to main earlier it didn't update the Apt cache after adding the new repo, then it installed the old client as a result.  This should fix that.