### PR TITLE
Dynmap proxy lol

### DIFF
--- a/ansible/roles/nginx-proxy/files/dynmap_proxy.conf
+++ b/ansible/roles/nginx-proxy/files/dynmap_proxy.conf
@@ -1,0 +1,13 @@
+#proxy_cache_path  /var/www/cache levels=1:2 keys_zone=my-cache:8m max_size=1000m inactive=600m;
+#proxy_temp_path /var/www/cache/tmp;
+server {
+  listen 8123;
+  location / {
+    proxy_pass http://10.101.22.220:8123;
+  }
+  proxy_buffers 16 4k;
+  proxy_buffer_size 2k;
+  proxy_cache my-cache;
+  proxy_cache_valid  200 302  60m;
+  proxy_cache_valid  404      1m;
+}

--- a/ansible/roles/nginx-proxy/tasks/firewall_rules.yaml
+++ b/ansible/roles/nginx-proxy/tasks/firewall_rules.yaml
@@ -5,6 +5,12 @@
     proto: tcp
     port: "80"
 
+- name: Allow port 8123 TCP for Dynmap proxy
+  community.general.ufw:
+    rule: allow
+    proto: tcp
+    port: "8123"
+
 - name: Reload UFW
   community.general.ufw:
     state: reloaded

--- a/ansible/roles/nginx-proxy/tasks/server.yaml
+++ b/ansible/roles/nginx-proxy/tasks/server.yaml
@@ -10,22 +10,28 @@
   notify:
     - Restart nginx
 
-- name: Copy repo_proxy.conf
+- name: Copy proxy configs
   ansible.builtin.copy:
-    src: files/repo_proxy.conf
-    dest: /etc/nginx/sites-available/repo_proxy.conf
+    src: "files/{{ item }}"
+    dest: "/etc/nginx/sites-available/{{ item }}"
     mode: "0644"
     owner: root
     group: root
+  with_items:
+    - "repo_proxy.conf"
+    - "dynmap_proxy.conf"
   notify:
     - Restart nginx
 
-- name: Link NGINX Reverse Proxy
+- name: Link reverse proxy configs
   ansible.builtin.file:
-    dest: /etc/nginx/sites-enabled/repo_proxy.conf
-    src: /etc/nginx/sites-available/repo_proxy.conf
+    dest: "/etc/nginx/sites-enabled/{{ item }}"
+    src: "/etc/nginx/sites-available/{{ item }}"
     state: link
     force: true
+  with_items:
+    - "repo_proxy.conf"
+    - "dynmap_proxy.conf"
   notify:
     - Restart nginx
 

--- a/ansible/roles/ubuntu/tasks/packages.yaml
+++ b/ansible/roles/ubuntu/tasks/packages.yaml
@@ -19,6 +19,10 @@
     group: root
     mode: 0644
 
+- name: Force Apt cache update
+  ansible.builtin.apt:
+    update_cache: true
+
 - name: Upgrade all system packages
   ansible.builtin.apt:
     upgrade: full


### PR DESCRIPTION
- Add a proxy config for the Dynmap for the Minecraft server, slightly more secure than a direct port forward
- Fix Apt choking on initial node creation